### PR TITLE
Revert "Update node-exporter"

### DIFF
--- a/helm/kubernetes-node-exporter-chart/values.yaml
+++ b/helm/kubernetes-node-exporter-chart/values.yaml
@@ -9,7 +9,7 @@ port: 10300
 image:
   registry: quay.io
   repository: giantswarm/node-exporter
-  tag: v0.17.0
+  tag: v0.15.1
 
 resources:
   limits:


### PR DESCRIPTION
Reverts giantswarm/kubernetes-node-exporter#29

That was too fast. New node-exporter has issues with old coreos we are using now