### PR TITLE
Fixes mount issues

### DIFF
--- a/helm/kubernetes-node-exporter-chart/Chart.yaml
+++ b/helm/kubernetes-node-exporter-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v0.15.1"
 description: A Helm chart for Kubernetes Node-Exporter Service
 name: kubernetes-node-exporter-chart
-version: 0.1.10-[[ .SHA ]]
+version: 0.1.11-[[ .SHA ]]

--- a/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
+++ b/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
@@ -24,6 +24,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      securityContext:
+        runAsUser: 0
       containers:
       - image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         name: {{ .Values.name }}
@@ -98,6 +100,8 @@ spec:
         - mountPath: /var/run/dbus/
           name: var-run-dbus
           readOnly: true
+        securityContext:
+          privileged: true
       volumes:
       - name: root
         hostPath:

--- a/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
+++ b/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
@@ -32,7 +32,10 @@ spec:
           containerPort: {{ .Values.port }}
         args:
         - '--log.level=info'
+        - '--path.procfs=/host/proc'
+        - '--path.sysfs=/host/sys'
         - '--web.listen-address=:{{ .Values.port }}'
+
         - '--collector.arp'
         - '--collector.bcache'
         - '--collector.conntrack'
@@ -43,7 +46,6 @@ spec:
         - '--collector.filefd'
         - '--collector.filesystem'
         - '--collector.hwmon'
-        - '--collector.infiniband'
         - '--collector.ipvs'
         - '--collector.loadavg'
         - '--collector.mdadm'
@@ -53,14 +55,16 @@ spec:
         - '--collector.sockstat'
         - '--collector.stat'
         - '--collector.systemd'
-        - '--no-collector.textfile'   # we don't use textfile collector.
         - '--collector.time'
         - '--collector.timex'
         - '--collector.uname'
         - '--collector.vmstat'
-        - '--no-collector.wifi'       # we don't use wifi.
         - '--collector.xfs'
-        - '--no-collector.zfs'        # we don't use zfs.
+
+        - '--no-collector.infiniband'
+        - '--no-collector.textfile'
+        - '--no-collector.wifi'
+        - '--no-collector.zfs'
         livenessProbe:
           httpGet:
             path: /
@@ -76,10 +80,41 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
+        - name: root
+          mountPath: /rootfs
+          readOnly: true
+        - name: proc
+          mountPath: /host/proc
+          readOnly: true
+        - name: sys
+          mountPath: /host/sys
+          readOnly: true
+        - name: var-lib-docker
+          mountPath: /var/lib/docker
+          readOnly: true
+        - name: var-lib-kubelet
+          mountPath: /var/lib/kubelet
+          readOnly: true
         - mountPath: /var/run/dbus/
-          name: systemd-volume
+          name: var-run-dbus
+          readOnly: true
       volumes:
-      - name: systemd-volume
+      - name: root
+        hostPath:
+          path: /
+      - name: proc
+        hostPath:
+          path: /proc
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: var-lib-docker
+        hostPath:
+          path: /var/lib/docker
+      - name: var-lib-kubelet
+        hostPath:
+          path: /var/lib/kubelet
+      - name: var-run-dbus
         hostPath:
           path: /var/run/dbus/
       serviceAccountName: {{ .Values.name }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5132

As the root / proc / sys volumes aren't mounted into the container,
we don't receive any alerts for disk space issues on tenant nodes.
This changeset adds the necessary mounts to provide metrics for disk space.