### PR TITLE
Disable diskstats collector

### DIFF
--- a/helm/kubernetes-node-exporter-chart/Chart.yaml
+++ b/helm/kubernetes-node-exporter-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v0.15.1"
 description: A Helm chart for Kubernetes Node-Exporter Service
 name: kubernetes-node-exporter-chart
-version: 0.1.11-[[ .SHA ]]
+version: 0.1.12-[[ .SHA ]]

--- a/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
+++ b/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
@@ -42,7 +42,6 @@ spec:
         - '--collector.bcache'
         - '--collector.conntrack'
         - '--collector.cpu'
-        - '--collector.diskstats'
         - '--collector.edac'
         - '--collector.entropy'
         - '--collector.filefd'
@@ -63,6 +62,7 @@ spec:
         - '--collector.vmstat'
         - '--collector.xfs'
 
+        - '--no-collector.diskstats'
         - '--no-collector.infiniband'
         - '--no-collector.textfile'
         - '--no-collector.wifi'


### PR DESCRIPTION
In Linux 4.19 there was a change in diskstats file format. Latest node_exporter
0.17.0 has a fix for this, but it's otherwise incompatible with old CoreOS we
are still running on some installations.

As we are not using diskstats metrics for anything at the moment, disable it to
silence disturbing alerts of failing metrics collection.