### PR TITLE
increasing cpu to 200m

### DIFF
--- a/helm/kubernetes-node-exporter-chart/values.yaml
+++ b/helm/kubernetes-node-exporter-chart/values.yaml
@@ -13,10 +13,10 @@ image:
 
 resources:
   limits:
-    cpu: 55m
+    cpu: 200m
     memory: 75Mi
   requests:
-    cpu: 55m
+    cpu: 200m
     memory: 75Mi
 
 test:


### PR DESCRIPTION
Towards: giantswarm/giantswarm#5659

We found out that there is some memory management issue on node-exporter, for the mean time increasing the cpu resources mitigate the issue.
upstream issue: https://github.com/prometheus/node_exporter/issues/1301

This PR replaces https://github.com/giantswarm/g8s-prometheus/pull/457