### PR TITLE
fix systemd collector dbus connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Fix systemd collector dbus connection. https://github.com/giantswarm/kubernetes-node-exporter/pull/44
+- Fix systemd collector D-Bus connection. https://github.com/giantswarm/kubernetes-node-exporter/pull/44
 
 ## [v0.4.0] 2019-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v0.4.1] 2019-06-28
+
+### Fixed
+
+- Fix systemd collector dbus connection. https://github.com/giantswarm/kubernetes-node-exporter/pull/44
+
 ## [v0.4.0] 2019-06-14
 
 ### Changed
@@ -28,7 +34,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Separate pod security policy for node-exporter and node-exporter-migration workloads.
 - Security context with non-root user (`nobody`) for running node-exporter inside container.
 
-[Unreleased]: https://github.com/giantswarm/kubernetes-node-exporter/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/giantswarm/kubernetes-node-exporter/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/giantswarm/kubernetes-node-exporter/releases/tag/v0.4.1
 [0.4.0]: https://github.com/giantswarm/kubernetes-node-exporter/releases/tag/v0.4.0
 [0.3.0]: https://github.com/giantswarm/kubernetes-node-exporter/releases/tag/v0.3.0
 [0.2.0]: https://github.com/giantswarm/kubernetes-node-exporter/releases/tag/v0.2.0

--- a/helm/kubernetes-node-exporter-chart/Chart.yaml
+++ b/helm/kubernetes-node-exporter-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v0.18.0"
 description: A Helm chart for Kubernetes Node-Exporter Service
 name: kubernetes-node-exporter-chart
-version: 0.4.0-[[ .SHA ]]
+version: 0.4.1-[[ .SHA ]]

--- a/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
+++ b/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
@@ -89,7 +89,7 @@ spec:
         # so --path.rootfs is not respected.
         # We mount the socket in to the correct path to get around this.
         - name: systemd
-          mountPath: /var/run/systemd
+          mountPath: /run/systemd
           readOnly: true
       volumes:
       - name: root
@@ -97,7 +97,7 @@ spec:
           path: /
       - name: systemd
         hostPath:
-          path: /var/run/systemd
+          path: /run/systemd
       serviceAccountName: {{ .Values.name }}
       hostNetwork: true
       hostPID: true

--- a/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
+++ b/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
@@ -85,6 +85,9 @@ spec:
         - name: root
           mountPath: /rootfs
           readOnly: true
+        - name: dbus
+          mountPath: /var/run/dbus/
+          readOnly: true
         # go-systemd hardcodes the systemd socket path,
         # so --path.rootfs is not respected.
         # We mount the socket in to the correct path to get around this.
@@ -95,6 +98,9 @@ spec:
       - name: root
         hostPath:
           path: /
+      - name: dbus
+        hostPath:
+          path: /var/run/dbus/
       - name: systemd
         hostPath:
           path: /run/systemd

--- a/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
+++ b/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
@@ -85,10 +85,19 @@ spec:
         - name: root
           mountPath: /rootfs
           readOnly: true
+        # go-systemd hardcodes the systemd socket path,
+        # so --path.rootfs is not respected.
+        # We mount the socket in to the correct path to get around this.
+        - name: systemd
+          mountPath: /run/systemd
+          readOnly: true
       volumes:
       - name: root
         hostPath:
           path: /
+      - name: systemd
+        hostPath:
+          path: /run/systemd
       serviceAccountName: {{ .Values.name }}
       hostNetwork: true
       hostPID: true

--- a/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
+++ b/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
@@ -89,7 +89,7 @@ spec:
         # so --path.rootfs is not respected.
         # We mount the socket in to the correct path to get around this.
         - name: systemd
-          mountPath: /run/systemd
+          mountPath: /var/run/systemd
           readOnly: true
       volumes:
       - name: root
@@ -97,7 +97,7 @@ spec:
           path: /
       - name: systemd
         hostPath:
-          path: /run/systemd
+          path: /var/run/systemd
       serviceAccountName: {{ .Values.name }}
       hostNetwork: true
       hostPID: true

--- a/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
+++ b/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
@@ -86,7 +86,7 @@ spec:
           mountPath: /rootfs
           readOnly: true
         - name: dbus
-          mountPath: /var/run/dbus/
+          mountPath: /var/run/dbus
           readOnly: true
         # go-systemd hardcodes the systemd socket path,
         # so --path.rootfs is not respected.
@@ -100,7 +100,7 @@ spec:
           path: /
       - name: dbus
         hostPath:
-          path: /var/run/dbus/
+          path: /var/run/dbus
       - name: systemd
         hostPath:
           path: /run/systemd

--- a/helm/kubernetes-node-exporter-chart/values.yaml
+++ b/helm/kubernetes-node-exporter-chart/values.yaml
@@ -6,13 +6,14 @@ name: node-exporter
 namespace: kube-system
 port: 10300
 
-userID: 65535
-groupID: 65535
+# Run as giantswarm user.
+userID: 1000
+groupID: 1000
 
 image:
   registry: quay.io
   repository: giantswarm/node-exporter
-  tag: v0.18.0
+  tag: v0.18.0-giantswarm
 
 resources:
   limits:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6178.

In order to be able to access dbus we need two things:
- Run container with the same user (including UID) as in the host system.
- Mount host `/var/run/dbus/system_bus_socket` file (this PR mounts `/var/run/dbus` directory because we feel more comfortable with mounting directories instead of regular files). 

Custom image is build here https://github.com/giantswarm/retagger/pull/234.