### PR TITLE
Use giantswarm-critical priority class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-## [0.5.0] 2019-07-17
+## [0.5.1] 2019-07-17
 
 ### Changed
 
 - Tolerations changed to tolerate all taints.
+- Change prioty class from to `giantswarm-critical`.
 
 ## [0.4.1] 2019-06-28
 

--- a/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
+++ b/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
@@ -25,6 +25,7 @@ spec:
       securityContext:
         runAsUser: {{ .Values.userID }}
         runAsGroup: {{ .Values.userGroup }}
+      priorityClassName: giantswarm-critical
       containers:
       - image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         name: {{ .Values.name }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6556
As daemonsets are scheduled with default scheduler starting from 1.12 by default - we can prioritize them as well