### PR TITLE
Add initContainer to change kubelet dir ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [0.5.1] 2019-07-17
 
+### Added
+
+- Add initContainer, which sets ownership of the `/var/lib/kubelet` directory to `giantswarm` group.
+
 ### Changed
 
 - Tolerations changed to tolerate all taints.
 - Change prioty class from to `giantswarm-critical`.
+- `PodSecurityPolicy` allows running containers with root user. That is used for initContainer, which sets ownership. 
 
 ## [0.4.1] 2019-06-28
 

--- a/helm/kubernetes-node-exporter-chart/Chart.yaml
+++ b/helm/kubernetes-node-exporter-chart/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v0.18.0"
 description: A Helm chart for Kubernetes Node-Exporter Service
 name: kubernetes-node-exporter-chart
-version: 0.5.0-[[ .SHA ]]
+version: 0.5.1-[[ .SHA ]]

--- a/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
+++ b/helm/kubernetes-node-exporter-chart/templates/daemonset.yaml
@@ -22,10 +22,20 @@ spec:
       tolerations:
       # Tolerate all taints for observability
       - operator: "Exists"
-      securityContext:
-        runAsUser: {{ .Values.userID }}
-        runAsGroup: {{ .Values.userGroup }}
       priorityClassName: giantswarm-critical
+      initContainers:
+      - name: {{ .Values.initContainer.name }}
+        image: {{ .Values.initContainer.image }}
+        command:
+        - /bin/sh
+        - -c
+        - "chown root:giantswarm /rootfs/var/lib/kubelet -R"
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: root
+          mountPath: /rootfs
+          readOnly: true
       containers:
       - image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         name: {{ .Values.name }}
@@ -80,6 +90,9 @@ spec:
           timeoutSeconds: 5
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        securityContext:
+          runAsUser: {{ .Values.userID }}
+          runAsGroup: {{ .Values.userGroup }}
         volumeMounts:
         - name: root
           mountPath: /rootfs

--- a/helm/kubernetes-node-exporter-chart/templates/psp.yaml
+++ b/helm/kubernetes-node-exporter-chart/templates/psp.yaml
@@ -7,9 +7,9 @@ metadata:
     giantswarm.io/service-type: "managed"
 spec:
   privileged: false
-  allowPrivilegeEscalation: true
+  allowPrivilegeEscalation: false
   runAsUser:
-    rule: MustRunAsNonRoot
+    rule: RunAsAny
   seLinux:
     rule: RunAsAny
   supplementalGroups:

--- a/helm/kubernetes-node-exporter-chart/values.yaml
+++ b/helm/kubernetes-node-exporter-chart/values.yaml
@@ -23,6 +23,10 @@ resources:
     cpu: 200m
     memory: 50Mi
 
+initContainer:
+  name: set-giantswarm-user-ownership
+  image: quay.io/giantswarm/alpine:3.9-giantswarm
+
 test:
   image:
     registry: quay.io


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6622

Allows running pod as root. This is used in initContainer. exporter itself is running as `giantswarm` user